### PR TITLE
Allow use without react

### DIFF
--- a/src/MultiAPILink.ts
+++ b/src/MultiAPILink.ts
@@ -1,4 +1,9 @@
-import { ApolloLink, NextLink, Operation, RequestHandler } from '@apollo/client'
+import {
+  ApolloLink,
+  NextLink,
+  Operation,
+  RequestHandler,
+} from '@apollo/client/core'
 import {
   getMainDefinition,
   hasDirectives,


### PR DESCRIPTION
Hi, thanks for the module!

I just made a small change to work around this import in `@apollo/client`: https://github.com/apollographql/apollo-client/blob/4159973f65f71f8cd44fa6ae249800fa677239d1/src/index.ts#L2, which eventually ends up trying to import react: https://github.com/apollographql/apollo-client/blob/4159973f65f71f8cd44fa6ae249800fa677239d1/src/react/hooks/useApolloClient.ts#L1

Avoiding that line allows a user to use this module without having react in the picture.